### PR TITLE
compare.exe improvements

### DIFF
--- a/tools/compare/compare.cs
+++ b/tools/compare/compare.cs
@@ -268,7 +268,7 @@ class Compare
 					Debug.Assert (benchmarkconfigs.Length == benchmarkconfigs.Distinct ().Count (), "There are duplicate configs for benchmark \"{0}\" : {1}",
 						benchmark.Key.Name, String.Join (", ", benchmarkconfigs.OrderBy (c => c.Name).Select (c => c.Name)));
 
-					if (benchmark.Any (r => r.Runs.Any (ru => ru.WallClockTime == TimeSpan.Zero))) {
+					if (benchmark.Any (r => r.Runs.Any (ru => ru.WallClockTime == TimeSpan.Zero || !string.IsNullOrEmpty(ru.Error)))) {
 						Console.WriteLine ("Don't have data for benchmark \"{0}\" in all configs - removing", benchmark.Key.Name);
 						return null;
 					}

--- a/tools/compare/compare.cs
+++ b/tools/compare/compare.cs
@@ -120,8 +120,15 @@ class Compare
 				if (result == null)
 					throw new InvalidDataException (String.Format ("Cannot load Result from {0}", resultfile));
 
-				if (results.Any (r => r.Benchmark.Equals (result.Benchmark) && r.Config.Equals (result.Config)))
-					continue;
+				foreach (var r in results) {
+					if (!r.Benchmark.Equals(result.Benchmark) || !r.Config.Equals (result.Config))
+						continue;
+
+					if (r.DateTime < result.DateTime)
+						results.Remove (r);
+
+					break;
+				}
 
 				results.Add (result);
 			}


### PR DESCRIPTION
compare.exe with option --no-run now uses most recent results.
compare.exe now skips a benchmark if any of its runs contains an error.