### PR TITLE
compare: add option in Configuration to disable printing of env vars

### DIFF
--- a/configs/auto-sgen-noenv.conf
+++ b/configs/auto-sgen-noenv.conf
@@ -1,0 +1,12 @@
+{
+  "Name": "auto-sgen-noenv",
+  "Count": 10,
+  "PrintEnv": false,
+  "Mono": "$ROOT/bin/mono-sgen",
+  "MonoOptions": [
+    "-O=-aot"
+  ],
+  "MonoEnvironmentVariables": {
+    "MONO_PATH": "$ROOT/lib/mono/4.5"
+  }
+}

--- a/tools/common/Models/Config.cs
+++ b/tools/common/Models/Config.cs
@@ -18,6 +18,7 @@ namespace Benchmarker.Common.Models
 		public string Name { get; set; }
 		public int Count { get; set; }
 		public bool NoMono {get; set; }
+		public bool PrintEnv  {get; set; } = true;
 		public string Mono { get; set; }
 		public string[] MonoOptions { get; set; }
 		public Dictionary<string, string> MonoEnvironmentVariables { get; set; }
@@ -91,8 +92,11 @@ namespace Benchmarker.Common.Models
 			return info;
 		}
 
-		public static string PrintableEnvironmentVariables (ProcessStartInfo info)
+		public string PrintableEnvironmentVariables (ProcessStartInfo info)
 		{
+			if (!PrintEnv) {
+				return "";
+			}
 			var builder = new StringBuilder ();
 			foreach (DictionaryEntry entry in info.EnvironmentVariables) {
 				builder.Append (entry.Key.ToString ());

--- a/tools/common/Runner.cs
+++ b/tools/common/Runner.cs
@@ -62,8 +62,8 @@ namespace Benchmarker.Common
 					Debug.Assert (profileFilename != null);
 				else
 					Debug.Assert (profileFilename == null);
-				
-				Console.Out.WriteLine ("\t$> {0} {1} {2}", Config.PrintableEnvironmentVariables (info), info.FileName, info.Arguments);
+
+				Console.Out.WriteLine ("\t$> {0} {1} {2}", config.PrintableEnvironmentVariables (info), info.FileName, info.Arguments);
 
 				/* Run with timing */
 				if (config.NoMono)


### PR DESCRIPTION
... because it clutters the output.  default behavior hasn't changed.

my first baby steps with c#, so please comment if something is not c#'ish.