### PR TITLE
configure intel x86_64 CPUs in a predictable state for benchmarking (linux)

### DIFF
--- a/jenkins-osx/poll-jenkins.sh
+++ b/jenkins-osx/poll-jenkins.sh
@@ -6,22 +6,22 @@ JQ_JOIN="reduce .[] as \$item (\"\"; . + \"\n\" + \$item)"
 
 case `uname -m` in
 i*86)
-	ARCH=i386
-	;;
+    ARCH=i386
+    ;;
 x86_64)
-	ARCH=amd64
-	;;
+    ARCH=amd64
+    ;;
 armv7*)
-	if [ -d "/lib/arm-linux-gnueabihf" ]; then
-		ARCH=armhf
-	else
-		ARCH=armel
-	fi
-	;;
+    if [ -d "/lib/arm-linux-gnueabihf" ]; then
+        ARCH=armhf
+    else
+        ARCH=armel
+    fi
+    ;;
 *)
-	echo "Error: Unsupported architecture"
-	exit 1
-	;;
+    echo "Error: Unsupported architecture"
+    exit 1
+    ;;
 esac
 
 LABEL="debian-$ARCH"
@@ -44,8 +44,8 @@ ERROR=0
 finish () {
     rm -rf "$TMP_DIR"
     if [ $? -ne 0 ] ; then
-	echo "Error: Cannot delete temporary directory $TMP_DIR"
-	ERROR=1
+        echo "Error: Cannot delete temporary directory $TMP_DIR"
+        ERROR=1
     fi
 
     exit $ERROR
@@ -57,97 +57,96 @@ BUILDS_TESTED_LIST="$TMP_DIR/builds-tested"
 BUILDS_ALL_LIST="$TMP_DIR/builds-all"
 
 while true ; do
-
     while true ; do
-	# get all the builds we've tested from Parse
-	curl -X GET \
-	     -H "X-Parse-Application-Id: 7khPUBga9c7L1YryD1se1bp6VRzKKJESc0baS9ES" \
-	     -H "X-Parse-REST-API-Key: xOHOwaDls0fcuMKLIH0nzaMKclLzCWllwClLej4d" \
-	     -G \
-	     --data-urlencode "where={\"buildURL\":{\"\$exists\":true},\"machine\":{\"\$inQuery\":{\"where\":{\"name\":\"$HOSTNAME\"},\"className\":\"Machine\"}}}" \
-	     https://api.parse.com/1/classes/RunSet | jq -r ".results | map(.buildURL) | sort | unique | $JQ_JOIN" >"$BUILDS_TESTED_LIST"
-	if [ $? -ne 0 ] ; then
-	    echo "Error: Cannot fetch JSON from Parse."
-	    sleep 60
-	    continue
-	fi
+        # get all the builds we've tested from Parse
+        curl -X GET \
+             -H "X-Parse-Application-Id: 7khPUBga9c7L1YryD1se1bp6VRzKKJESc0baS9ES" \
+             -H "X-Parse-REST-API-Key: xOHOwaDls0fcuMKLIH0nzaMKclLzCWllwClLej4d" \
+             -G \
+             --data-urlencode "where={\"buildURL\":{\"\$exists\":true},\"machine\":{\"\$inQuery\":{\"where\":{\"name\":\"$HOSTNAME\"},\"className\":\"Machine\"}}}" \
+             https://api.parse.com/1/classes/RunSet | jq -r ".results | map(.buildURL) | sort | unique | $JQ_JOIN" >"$BUILDS_TESTED_LIST"
+        if [ $? -ne 0 ] ; then
+            echo "Error: Cannot fetch JSON from Parse."
+            sleep 60
+            continue
+        fi
 
-	# get information on all builds Jenkins has built
-	curl "https://jenkins.mono-project.com/view/All/job/build-package-dpkg-mono/label=$LABEL/api/json?pretty=true&tree=allBuilds\[fingerprint\[original\[*\]\],artifacts\[*\],url,building\]" | jq ".allBuilds | map(select(.building | not))" >"$JENKINS_JSON"
-	if [ $? -ne 0 ] ; then
-	    echo "Error: Cannot fetch JSON from Jenkins."
-	    sleep 60
-	    continue
-	fi
+        # get information on all builds Jenkins has built
+        curl "https://jenkins.mono-project.com/view/All/job/build-package-dpkg-mono/label=$LABEL/api/json?pretty=true&tree=allBuilds\[fingerprint\[original\[*\]\],artifacts\[*\],url,building\]" | jq ".allBuilds | map(select(.building | not))" >"$JENKINS_JSON"
+        if [ $? -ne 0 ] ; then
+            echo "Error: Cannot fetch JSON from Jenkins."
+            sleep 60
+            continue
+        fi
 
-	# filter out the URLs from the list from Jenkins
-	cat "$JENKINS_JSON" | jq -r "map(.url) | sort | unique | $JQ_JOIN" >"$BUILDS_ALL_LIST"
-	if [ $? -ne 0 ] ; then
-	    echo "Error: Cannot get all builds from JSON."
-	    sleep 60
-	    continue
-	fi
+        # filter out the URLs from the list from Jenkins
+        cat "$JENKINS_JSON" | jq -r "map(.url) | sort | unique | $JQ_JOIN" >"$BUILDS_ALL_LIST"
+        if [ $? -ne 0 ] ; then
+            echo "Error: Cannot get all builds from JSON."
+            sleep 60
+            continue
+        fi
 
-	# get a list of all the runs we haven't yet tested
-	RUN_URL=`comm -2 -3 "$BUILDS_ALL_LIST" "$BUILDS_TESTED_LIST" | tail -n 1`
-	if [ "x$RUN_URL" = "x" ] ; then
-	    echo "We've tested all the builds.  Sleeping."
-	    sleep 300
-	    continue
-	fi
+        # get a list of all the runs we haven't yet tested
+        RUN_URL=`comm -2 -3 "$BUILDS_ALL_LIST" "$BUILDS_TESTED_LIST" | tail -n 1`
+        if [ "x$RUN_URL" = "x" ] ; then
+            echo "We've tested all the builds.  Sleeping."
+            sleep 300
+            continue
+        fi
 
-	echo "Build to test is $RUN_URL"
+        echo "Build to test is $RUN_URL"
 
-	cat "$JENKINS_JSON" | jq -r "map(select(.url==\"$RUN_URL\")) | add" >"$RUN_JSON"
-	if [ $? -ne 0 ] ; then
-	    echo "Error: Cannot get run from JSON."
-	    sleep 60
-	    continue
-	fi
+        cat "$JENKINS_JSON" | jq -r "map(select(.url==\"$RUN_URL\")) | add" >"$RUN_JSON"
+        if [ $? -ne 0 ] ; then
+            echo "Error: Cannot get run from JSON."
+            sleep 60
+            continue
+        fi
 
-	break
+        break
     done
 
     GIT_FETCH_ID=`cat "$RUN_JSON" | jq -r '.fingerprint | map (select(.original.name == "build-source-tarball-mono")) | add | .original.number'`
     if [ $? -ne 0 ] ; then
-	echo "Error: Cannot get URL from JSON."
-	sleep 60
-	continue
+        echo "Error: Cannot get URL from JSON."
+        sleep 60
+        continue
     fi
 
     if [ "x$ARCH" != "xamd64" ] ; then
-	AMD64_RUN_URL=`echo $RUN_URL | sed "s/$ARCH/amd64/"`
+        AMD64_RUN_URL=`echo $RUN_URL | sed "s/$ARCH/amd64/"`
 
-	ASM_PATH=`curl "$AMD64_RUN_URL/api/json?pretty=true&tree=artifacts\[*\]" | jq -r '.artifacts | map (.relativePath) | map(select(contains(".changes") | not)) | map(select(contains("assemblies")))[0]'`
-	if [ $? -ne 0 ] ; then
-	    echo "Error: Cannot fetch ASSEMBLIES JSON from Jenkins."
-	    sleep 60
-	    continue
-	fi
-	ASM_URL="$AMD64_RUN_URL/artifact/$ASM_PATH"
+        ASM_PATH=`curl "$AMD64_RUN_URL/api/json?pretty=true&tree=artifacts\[*\]" | jq -r '.artifacts | map (.relativePath) | map(select(contains(".changes") | not)) | map(select(contains("assemblies")))[0]'`
+        if [ $? -ne 0 ] ; then
+            echo "Error: Cannot fetch ASSEMBLIES JSON from Jenkins."
+            sleep 60
+            continue
+        fi
+        ASM_URL="$AMD64_RUN_URL/artifact/$ASM_PATH"
     else
-	ASM_PATH=`cat "$RUN_JSON" | jq -r '.artifacts | map (.relativePath) | map(select(contains(".changes") | not)) | map(select(contains("assemblies")))[0]'`
-	if [ $? -ne 0 ] || [ "x$ASM_PATH" = "xnull" ]  ; then
-	    echo "Error: Cannot get assemblies package from JSON."
-	    sleep 60
-	    continue
-	fi
-	ASM_URL="$RUN_URL/artifact/$ASM_PATH"
+        ASM_PATH=`cat "$RUN_JSON" | jq -r '.artifacts | map (.relativePath) | map(select(contains(".changes") | not)) | map(select(contains("assemblies")))[0]'`
+        if [ $? -ne 0 ] || [ "x$ASM_PATH" = "xnull" ]  ; then
+            echo "Error: Cannot get assemblies package from JSON."
+            sleep 60
+            continue
+        fi
+        ASM_URL="$RUN_URL/artifact/$ASM_PATH"
     fi
 
     BIN_PATH=`cat "$RUN_JSON" | jq -r ".artifacts | map (.relativePath) | map(select(contains(\".changes\") | not)) | map(select(contains(\"$ARCH\")))[0]"`
     if [ $? -ne 0 ] ; then
-	echo "Error: Cannot get binary package from JSON."
-	sleep 60
-	continue
+        echo "Error: Cannot get binary package from JSON."
+        sleep 60
+        continue
     fi
     BIN_URL="$RUN_URL/artifact/$BIN_PATH"
 
     COMMIT_SHA=`curl "https://jenkins.mono-project.com/job/build-source-tarball-mono/$GIT_FETCH_ID/pollingLog/pollingLog" | awk '/Latest remote/ { print $NF }'`
     if [ $? -ne 0 -o "x$COMMIT_SHA" = "x" ] ; then
-	echo "Error: Cannot get commit SHA."
-	sleep 60
-	continue
+        echo "Error: Cannot get commit SHA."
+        sleep 60
+        continue
     fi
 
     echo $RUN_URL
@@ -158,11 +157,10 @@ while true ; do
 
     "$BENCHMARKER_ROOT/jenkins-osx/run.sh" --arch $ARCH --config auto-sgen --commit "$COMMIT_SHA" --build-url "$RUN_URL" --deb-urls "$ASM_URL" "$BIN_URL"
     if [ $? -ne 0 ] ; then
-	echo "Error: Could not run benchmark."
-	sleep 60
-	continue
+        echo "Error: Could not run benchmark."
+        sleep 60
+        continue
     fi
-
 done
 
 finish

--- a/jenkins-osx/run.sh
+++ b/jenkins-osx/run.sh
@@ -35,43 +35,56 @@ usage () {
 
 while [ "$1" != "" ]; do
     case $1 in
-	--arch )		shift
-				ARCH=$1
-				;;
-	--config )		shift
-				CONFIG_NAME=$1
-				;;
-	--commit )		shift
-				COMMIT=$1
-				;;
-	--build-url )		shift
-				BUILD_URL=$1
-				;;
-	--install-only )	INSTALL_ONLY=true
-				;;
-	--benchmarks )		shift
-				BENCHMARKS="--benchmarks $1"
-				;;
-        --pkg-file )   	        shift
-                       		MONO_PKG=$1
-                          	;;
-        --pkg-url )            	shift
-                           	MONO_PKG_URL=$1
-                           	;;
-	--snapshot-url )	shift
-				SNAPSHOT_URL=$1
-				;;
-	--deb-urls )		shift
-				DEB_ASM_URL=$1
-				shift
-				DEB_BIN_URL=$1
-				;;
-	--deb-common-url )	shift
-				DEB_COMMON_URL=$1
-				;;
-        -h | --help )           usage 0
-                                ;;
-        * )                     usage 1
+        --arch )
+            shift
+            ARCH=$1
+            ;;
+        --config )
+            shift
+            CONFIG_NAME=$1
+            ;;
+        --commit )
+            shift
+            COMMIT=$1
+            ;;
+        --build-url )
+            shift
+            BUILD_URL=$1
+            ;;
+        --install-only )
+            INSTALL_ONLY=true
+            ;;
+        --benchmarks )
+            shift
+            BENCHMARKS="--benchmarks $1"
+            ;;
+        --pkg-file )
+            shift
+            MONO_PKG=$1
+            ;;
+        --pkg-url )
+            shift
+            MONO_PKG_URL=$1
+            ;;
+        --snapshot-url )
+            shift
+            SNAPSHOT_URL=$1
+            ;;
+        --deb-urls )
+            shift
+            DEB_ASM_URL=$1
+            shift
+            DEB_BIN_URL=$1
+            ;;
+        --deb-common-url )
+            shift
+            DEB_COMMON_URL=$1
+            ;;
+        -h | --help )
+            usage 0
+            ;;
+        * )
+            usage 1
     esac
     shift
 done
@@ -100,45 +113,45 @@ if [ "x$SNAPSHOT_URL" != "x" ] ; then
 
     lynx -dump -hiddenlinks=listonly -listonly "$SNAPSHOT_URL" | awk '$1 ~ /[0-9]+\./ { print $2 }' >"snapshot-links"
     if [ $? -ne 0 ] ; then
-	echo "Error: Could not get links from snapshot URL"
-	exit 1
+        echo "Error: Could not get links from snapshot URL"
+        exit 1
     fi
 
     DEBIAN_TAR_URL=`grep '\.debian\.tar\.bz2' "snapshot-links"`
     if [ $? -ne 0 -o "x$DEBIAN_TAR_URL" = "x" ] ; then
-	echo "Error: Could not get .debian.tar.bz2 link from snapshot URL"
-	exit 1
+        echo "Error: Could not get .debian.tar.bz2 link from snapshot URL"
+        exit 1
     fi
 
     curl -o "$TMP_DIR/debian.tar.bz2" "$DEBIAN_TAR_URL"
     if [ $? -ne 0 ] ; then
-	echo "Error: Could not fetch .debian.tar.bz2 from $DEBIAN_TAR_URL"
-	exit 1
+        echo "Error: Could not fetch .debian.tar.bz2 from $DEBIAN_TAR_URL"
+        exit 1
     fi
 
 
     tar -jxvf "debian.tar.bz2"
     if [ $? -ne 0 ] ; then
-	echo "Error: Could not untar debian.tar.bz2"
-	exit 1
+        echo "Error: Could not untar debian.tar.bz2"
+        exit 1
     fi
 
     SHORT_COMMIT=`perl -n -e '/commit ID ([0-9a-f]+)/ && print $1' debian/changelog`
     if [ $? -ne 0 ] ; then
-	echo "Error: Could not get commit ID from debian.tar.bz2"
-	exit 1
+        echo "Error: Could not get commit ID from debian.tar.bz2"
+        exit 1
     fi
 
     DEB_ASM_URL=`grep '-assemblies' "snapshot-links"`
     if [ $? -ne 0 -o "x$DEB_ASM_URL" = "x" ] ; then
-	echo "Error: Could not get assemblies package link from snapshot URL"
-	exit 1
+        echo "Error: Could not get assemblies package link from snapshot URL"
+        exit 1
     fi
 
     DEB_BIN_URL=`grep "$ARCH\.deb" "snapshot-links"`
     if [ $? -ne 0 -o "x$DEB_BIN_URL" = "x" ] ; then
-	echo "Error: Could not get binary package link from snapshot URL"
-	exit 1
+        echo "Error: Could not get binary package link from snapshot URL"
+        exit 1
     fi
 
     rm -rf "debian.tar.bz2" "debian" "snapshot-links"
@@ -185,23 +198,23 @@ ERROR=0
 
 finish () {
     if [ "$OS" = "Darwin" ] ; then
-	if [ $MOUNTED -ne 0 ] ; then
-	    diskutil umount force "$VOLPATH"
-	    if [ $? -ne 0 ] ; then
-		echo "Error: Cannot unmount disk image"
-		ERROR=1
-	    fi
-	fi
+        if [ $MOUNTED -ne 0 ] ; then
+            diskutil umount force "$VOLPATH"
+            if [ $? -ne 0 ] ; then
+                echo "Error: Cannot unmount disk image"
+                ERROR=1
+            fi
+        fi
     fi
 
     if [ "$OS" = "Linux" ] ; then
-	sudo /bin/rm -rf "$TMP_DIR"
+        sudo /bin/rm -rf "$TMP_DIR"
     else
-	rm -rf "$TMP_DIR"
+        rm -rf "$TMP_DIR"
     fi
     if [ $? -ne 0 ] ; then
-	echo "Error: Cannot delete temporary directory $TMP_DIR"
-	ERROR=1
+        echo "Error: Cannot delete temporary directory $TMP_DIR"
+        ERROR=1
     fi
 
     exit $ERROR
@@ -220,40 +233,40 @@ init_darwin () {
     MOUNTED=0
 
     if [ "x$MONO_PKG" = "x" -a "x$MONO_PKG_URL" = "x" ] ; then
-	echo "Error: No package file or URL given"
-	exit 1
+        echo "Error: No package file or URL given"
+        exit 1
     fi
 
     if [ "x$MONO_PKG" = "x" ] ; then
-	MONO_PKG="$TMP_DIR/installer.pkg"
-	curl -o "$MONO_PKG" "$MONO_URL"
-	if [ $? -ne 0 ] ; then
-	    error "Error: Could not download Mono package from $MONO_URL"
-	fi
+        MONO_PKG="$TMP_DIR/installer.pkg"
+        curl -o "$MONO_PKG" "$MONO_URL"
+        if [ $? -ne 0 ] ; then
+            error "Error: Could not download Mono package from $MONO_URL"
+        fi
     fi
 
     DMGPATH="$TMP_DIR/installation.dmg"
     hdiutil create "$DMGPATH" -volname "$VOLNAME" -size 1g -fs HFSX -attach
     if [ $? -ne 0 ] ; then
-	echo Error creating or mounting disk image
-	exit 1
+        echo Error creating or mounting disk image
+        exit 1
     fi
     MOUNTED=1
 
     sudo installer -package "$MONO_PKG" -target "$VOLPATH"
     if [ $? -ne 0 ] ; then
-	echo Error installing Mono package
-	ERROR=1
-	finish
+        echo Error installing Mono package
+        ERROR=1
+        finish
     fi
 
     VERSION=`ls "$VOLPATH/Library/Frameworks/Mono.framework/Versions" | grep -v Current`
     if [ $? -ne 0 ] ; then
-	error Error figuring out Mono version
+        error Error figuring out Mono version
     fi
 
     if [ `echo "$VERSION" | wc -w` -ne 1 ] ; then
-	error No unique Mono version in package
+        error No unique Mono version in package
     fi
 
     MONO_ROOT="$VOLPATH/Library/Frameworks/Mono.framework/Versions/$VERSION"
@@ -261,55 +274,55 @@ init_darwin () {
 
 init_linux () {
     if [ "x$DEB_ASM_URL" = "x" -o "x$DEB_BIN_URL" = "x" -o "x$DEB_COMMON_URL" = "x" ] ; then
-	error "Error: Debian package URLs not given"
+        error "Error: Debian package URLs not given"
     fi
 
     curl -o "$TMP_DIR/common.deb" "$DEB_COMMON_URL"
     if [ $? -ne 0 ] ; then
-	error "Error: Could not download mono-snapshot-common package."
+        error "Error: Could not download mono-snapshot-common package."
     fi
 
     curl -o "$TMP_DIR/assemblies.deb" "$DEB_ASM_URL"
     if [ $? -ne 0 ] ; then
-	error "Error: Could not download mono-snapshot-assemblies package."
+        error "Error: Could not download mono-snapshot-assemblies package."
     fi
 
     curl -o "$TMP_DIR/mono.deb" "$DEB_BIN_URL"
     if [ $? -ne 0 ] ; then
-	error "Error: Could not download mono-snapshot package."
+        error "Error: Could not download mono-snapshot package."
     fi
 
     INSTALL_ROOT="$TMP_DIR/installation"
 
     mkdir -p "$INSTALL_ROOT/var/lib"
     if [ $? -ne 0 ] ; then
-	error "Error: Could not create directory for dpkg."
+        error "Error: Could not create directory for dpkg."
     fi
 
     cp -a /var/lib/dpkg "$INSTALL_ROOT/var/lib/"
 
     sudo /usr/bin/dpkg --root="$INSTALL_ROOT" --unpack "$TMP_DIR/common.deb"
     if [ $? -ne 0 ] ; then
-	error "Error: Could not install mono-snapshot-common package."
+        error "Error: Could not install mono-snapshot-common package."
     fi
 
     sudo /usr/bin/dpkg --root="$INSTALL_ROOT" --unpack "$TMP_DIR/assemblies.deb"
     if [ $? -ne 0 ] ; then
-	error "Error: Could not install mono-snapshot-assemblies package."
+        error "Error: Could not install mono-snapshot-assemblies package."
     fi
 
     sudo /usr/bin/dpkg --root="$INSTALL_ROOT" --unpack "$TMP_DIR/mono.deb"
     if [ $? -ne 0 ] ; then
-	error "Error: Could not install mono-snapshot package."
+        error "Error: Could not install mono-snapshot package."
     fi
 
     VERSION=`ls "$INSTALL_ROOT/opt"`
     if [ $? -ne 0 ] ; then
-	error "Error: Nothing installed in /opt."
+        error "Error: Nothing installed in /opt."
     fi
 
     if [ `echo "$VERSION" | wc -w` -ne 1 ] ; then
-	error No unique Mono version in package
+        error No unique Mono version in package
     fi
 
     echo Mono version is $VERSION
@@ -325,13 +338,16 @@ init_linux () {
 
 OS=`uname`
 case "$OS" in
-    Darwin )	init_darwin
-		;;
-    Linux )	init_linux
-		;;
-    * )		echo "Unsupported OS $OS"
-		exit 1
-		;;
+    Darwin )
+        init_darwin
+        ;;
+    Linux )
+        init_linux
+        ;;
+    * )
+        echo "Unsupported OS $OS"
+        exit 1
+        ;;
 esac
 
 MONO_PATH="$MONO_ROOT/bin/mono-sgen"


### PR DESCRIPTION
The first commit contains whitespace changes. The second commit is actually the one with the relevant changes.
I accepted the fact that I'll never understand the performance model of nowadays Intel CPUs. However, we can at least do a few things to make benchmarking more stable.
* **Disable turbo mode**. The CPU enters turbo mode only when certain conditions are met, e.g. temperature is under a certain threshold. While the turbo mode is a good idea in order to achieve higher performance in general, it hurts to get stable results on the benchmark, since one cannot tell in which mode the CPU will operate.
* **Forcing C0 state**. it keeps the CPU in an active state, therefore latency is lower. But pay attention, this is very bad for power consumption, so don't do that at home.
