### PR TITLE
Use the geometric mean in the timeline.

### DIFF
--- a/front-end/src/common.js
+++ b/front-end/src/common.js
@@ -319,10 +319,11 @@ var timelineOptions = {
 						"bullet": "round",
 						"bulletSize": 4,
 						"lineColor": "#3498DB",
-						"id": "average",
-						"title": "average",
-						"valueField": "average"
+						"id": "geomean",
+						"title": "geomean",
+						"valueField": "geomean"
 					}
+
 				],
 				"guides": [],
 				"valueAxes": [

--- a/front-end/src/timeline.js
+++ b/front-end/src/timeline.js
@@ -235,7 +235,7 @@ class Chart extends xp_common.GoogleChartsStateComponent {
 		var table = [];
 
 		for (j = 0; j < runSets.length; ++j) {
-			var sumForRunSet = 0;
+			var prodForRunSet = 1.0;
 			var count = 0;
 			var min = undefined;
 			var minName = undefined;
@@ -245,7 +245,7 @@ class Chart extends xp_common.GoogleChartsStateComponent {
 				var val = runMetricsTable [i] [j];
 				if (isNaN (val))
 					continue;
-				sumForRunSet += val;
+				prodForRunSet *= val;
 				if (min === undefined || val < min) {
 					min = val;
 					minName = allBenchmarks [i].get ('name');
@@ -262,7 +262,7 @@ class Chart extends xp_common.GoogleChartsStateComponent {
 				lowName: minName,
 				high: max,
 				highName: maxName,
-				average: sumForRunSet / count,
+				geomean: Math.pow (prodForRunSet, 1.0 / count),
 				tooltip: tooltip
 			});
 		}


### PR DESCRIPTION
Using the geometric mean instead of the arithmetic mean should provide a more overall balanced metric.