### PR TITLE
Do not hardcode the parse credentials.

### DIFF
--- a/tools/common/Models/Credentials.cs
+++ b/tools/common/Models/Credentials.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace Benchmarker.Common.Models
+{
+	public class Credentials
+	{
+		public string Username { get; set; }
+		public string Password { get; set; }
+
+		public Credentials ()
+		{
+		}
+
+		public static void WriteToFile (Credentials credentials, string filename)
+		{
+			try {
+				using (FileStream fileStream = File.Open (filename, FileMode.Create, FileAccess.Write)) {
+					using (var streamWriter = new StreamWriter (fileStream)) {
+						streamWriter.Write (JsonConvert.SerializeObject (credentials));
+					}
+				}
+			} catch (Exception) {
+				Console.WriteLine ("Failed to save credentials to disk");
+			}
+		}
+
+		public static Credentials LoadFromFile (string filename)
+		{
+			try {
+				using (var reader = new StreamReader (new FileStream (filename, FileMode.Open))) {
+					return Credentials.LoadFromString (reader.ReadToEnd ());
+				}
+			} catch (Exception) {
+				return null;
+			}
+		}
+
+		public static Credentials LoadFromString (string str)
+		{
+			try {
+				return JsonConvert.DeserializeObject<Credentials> (str);
+			} catch (Exception) {
+				return null;
+			}
+		}
+	}
+}

--- a/tools/common/ParseInterface.cs
+++ b/tools/common/ParseInterface.cs
@@ -1,18 +1,82 @@
 ﻿using System;
 using Parse;
 using Nito.AsyncEx;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
+using Benchmarker.Common.Models;
 
 namespace Benchmarker.Common
 {
 	public class ParseInterface
 	{
+		private const string parseCredentialsFilename = "parse.pw";
+
 		static ParseACL defaultACL;
+
+		private static void WaitForConfirmation (string key)
+		{
+			Console.WriteLine ("Log in on browser for access, confirmation key {0}", key);
+			ParseQuery<ParseObject> query = ParseObject.GetQuery ("CredentialsResponse").WhereEqualTo ("key", key);
+			while (true) {
+				var task = query.FirstOrDefaultAsync ();
+				task.Wait ();
+
+				var result = task.Result;
+				if (result != null)
+					break;
+				Thread.Sleep (1000);
+			}
+			Console.WriteLine ("Login successful");
+		}
+
+		private static string GetResponse (string url, string parameters)
+		{
+			WebRequest webRequest = WebRequest.Create(url);
+			byte[] dataStream = Encoding.UTF8.GetBytes (parameters);
+			webRequest.Method = "POST";
+			webRequest.ContentType = "application/x-www-form-urlencoded";
+			webRequest.ContentLength = dataStream.Length;
+			using (Stream requestStream = webRequest.GetRequestStream ()) {
+				requestStream.Write (dataStream, 0, dataStream.Length);
+			}
+			WebResponse webResponse = webRequest.GetResponse ();
+			string response = new StreamReader(webResponse.GetResponseStream ()).ReadToEnd ();
+			return response;
+		}
 
 		public static bool Initialize ()
 		{
 			try {
+				Credentials credentials;
+
 				ParseClient.Initialize ("7khPUBga9c7L1YryD1se1bp6VRzKKJESc0baS9ES", "FwqUX9gNQP5HmP16xDcZRoh0jJRCDvdoDpv8L87p");
-				var user = AsyncContext.Run (() => ParseUser.LogInAsync ("benchmarker", "WhammyJammy"));
+
+				credentials = Credentials.LoadFromFile (parseCredentialsFilename);
+
+				if (credentials == null) {
+					string key = Guid.NewGuid ().ToString ();
+					string secret = Guid.NewGuid ().ToString ();
+
+					/* Get github OAuth authentication link */
+					string oauthLink = GetResponse ("https://benchmarker.parseapp.com/requestCredentials", string.Format("service=benchmarker&key={0}&secret={1}", key, secret));
+
+					/* Log in github OAuth */
+					System.Diagnostics.Process.Start (oauthLink);
+
+					/* Wait for login confirmation */
+					WaitForConfirmation (key);
+
+					/* Request the password */
+					credentials = Credentials.LoadFromString (GetResponse ("https://benchmarker.parseapp.com/getCredentials", string.Format ("key={0}&secret={1}", key, secret)));
+
+					/* Cache it in the current folder for future use */
+					Credentials.WriteToFile (credentials, parseCredentialsFilename);
+
+				}
+
+				var user = AsyncContext.Run (() => ParseUser.LogInAsync (credentials.Username, credentials.Password));
 
 				Console.WriteLine ("User authenticated: " + user.IsAuthenticated);
 
@@ -21,7 +85,8 @@ namespace Benchmarker.Common
 				acl.PublicWriteAccess = false;
 
 				defaultACL = acl;
-			} catch (Exception) {
+			} catch (Exception e) {
+				Console.WriteLine ("Exception : {0}", e.Message);
 				return false;
 			}
 			return true;

--- a/tools/common/common.csproj
+++ b/tools/common/common.csproj
@@ -37,6 +37,7 @@
     <Compile Include="Git\Repository.cs" />
     <Compile Include="ParseInterface.cs" />
     <Compile Include="Models\Machine.cs" />
+    <Compile Include="Models\Credentials.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Fetch them securely from the parse service, which uses github OAuth. Cache the credentials on the disk so we don't need to login at every run.