### PR TITLE
travis: add building js front-end

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
 language: csharp
+before_script:
+    - npm i -g eslint
+    - npm i -g babel-eslint
+    - npm i -g eslint-plugin-react
+    - make -C front-end
+    - make -C front-end lint
 solution: tools/tools.sln


### PR DESCRIPTION
travis ci doesn't support multiple languages yet, but we can misuse the `before_script` target for that.