### PR TITLE
Support tests that need a separate client application to operate, re-enable Eventstore.

### DIFF
--- a/benchmarks/eventstore.benchmark
+++ b/benchmarks/eventstore.benchmark
@@ -1,0 +1,6 @@
+{
+  "Name": "eventstore",
+  "TestDirectory": "Eventstore",
+  "CommandLine": ["EventStore.ClusterNode.exe --force"],
+  "ClientCommandLine": ["EventStore.TestClient.exe --force --command 'wrfl 10 500000'"]
+}

--- a/tests/Eventstore/run.py
+++ b/tests/Eventstore/run.py
@@ -8,7 +8,7 @@ exitcode = 0
 cmd = ' '.join (sys.argv [1:])
 
 def server ():
-    pserver = subprocess.Popen ("%s EventStore.ClusterNode.exe" % (mono), shell=True, stdout=sys.stderr)
+    pserver = subprocess.Popen ("%s EventStore.ClusterNode.exe --force" % (mono), shell=True, stdout=sys.stderr)
     kill.acquire ()
     pserver.kill ()
     pserver.wait ()
@@ -16,9 +16,9 @@ def server ():
 def client ():
     time.sleep (10)
 
-    if subprocess.Popen("%s EventStore.TestClient.exe --command ping" % (mono), shell=True, stdout=sys.stderr).wait () == 0:
+    if subprocess.Popen("%s EventStore.TestClient.exe --force --command ping" % (mono), shell=True, stdout=sys.stderr).wait () == 0:
         start = time.time ()
-        s = subprocess.Popen("%s EventStore.TestClient.exe --command '%s'" % (mono, cmd if len (cmd.strip ()) > 0 else "wrfl 10 1000000"), shell=True, stdout=sys.stderr).wait ()
+        s = subprocess.Popen("%s EventStore.TestClient.exe --force --command '%s'" % (mono, cmd if len (cmd.strip ()) > 0 else "wrfl 10 1000000"), shell=True, stdout=sys.stderr).wait ()
         end = time.time ()
         if s == 0:
             print (end - start)

--- a/tools/libdbmodel/Benchmark.cs
+++ b/tools/libdbmodel/Benchmark.cs
@@ -13,6 +13,7 @@ namespace Benchmarker.Models
 		public string Name { get; set; }
 		public string TestDirectory { get; set; }
 		public string[] CommandLine { get; set; }
+		public string[] ClientCommandLine { get; set; }
 
 		static Dictionary<string, PostgresRow> nameToRow;
 


### PR DESCRIPTION
Hello,

These changes add support for tests adhering to the client-server model that need a separate client application to operate. They also add a new benchmark file for Eventstore, thus re-enabling it, and fix the old standalone Python launcher for that test so that it would work again.

The code is kind of ugly, and I'd love to hear your thoughts how it could be improved.