### PR TITLE
compare: add AOT support

### DIFF
--- a/benchmarks/roslyn.benchmark
+++ b/benchmarks/roslyn.benchmark
@@ -1,6 +1,7 @@
 {
   "Name": "roslyn",
   "TestDirectory": "roslyn/corlib",
+  "AOTAssemblies": ["../roslyn/BoundTreeGenerator.exe", "../roslyn/CSharpErrorFactsGenerator.exe", "../roslyn/CSharpSyntaxGenerator.exe", "../roslyn/csc.exe", "../roslyn/Microsoft.CodeAnalysis.CSharp.Desktop.dll", "../roslyn/Microsoft.CodeAnalysis.CSharp.dll", "../roslyn/Microsoft.CodeAnalysis.Desktop.dll", "../roslyn/Microsoft.CodeAnalysis.dll", "../roslyn/System.Collections.Immutable.dll", "../roslyn/System.Reflection.Metadata.dll"],
   "CommandLine": [
     "../roslyn/csc.exe", "/codepage:65001", "-unsafe", "-nostdlib", "-nowarn:612,618", "-d:INSIDE_CORLIB", "-d:LIBC", "-d:NET_1_1", "-d:NET_2_0", "-d:NET_3_0", "-d:NET_3_5", "-d:NET_4_0", "-d:NET_4_5",
     "-nowarn:1699", "-nostdlib", "/noconfig", "-resource:resources/collation.core.bin", "-resource:resources/collation.tailoring.bin", "-resource:resources/collation.cjkCHS.bin", "-resource:resources/collation.cjkCHT.bin",

--- a/configs/auto-sgen-aotjit-serial-binary.conf
+++ b/configs/auto-sgen-aotjit-serial-binary.conf
@@ -3,7 +3,7 @@
   "Count": 10,
   "Mono": "$ROOT/bin/mono-sgen",
   "AOTOptions": [
-    "-O=all",
+    "-O=gsharedvt",
     "--aot"
   ],
   "MonoOptions": [

--- a/configs/auto-sgen-aotjit-serial-binary.conf
+++ b/configs/auto-sgen-aotjit-serial-binary.conf
@@ -1,0 +1,18 @@
+{
+  "Name": "auto-sgen-aotjit-serial-binary",
+  "Count": 10,
+  "Mono": "$ROOT/bin/mono-sgen",
+  "AOTOptions": [
+    "-O=all",
+    "--aot"
+  ],
+  "MonoOptions": [
+    "-O=aot"
+  ],
+  "MonoEnvironmentVariables": {
+    "MONO_PATH": "$ROOT/lib/mono/4.5",
+    "MONO_GC_PARAMS": "major=marksweep",
+    "MONO_GC_DEBUG": "binary-protocol=$BINPROT:0"
+  }
+}
+

--- a/http-api/data.go
+++ b/http-api/data.go
@@ -141,6 +141,7 @@ func metricIsAllowed(metric string, value interface{}) bool {
 	}
 
 	if metric == "time" ||
+		metric == "aot-time" ||
 		metric == "instructions" ||
 		metric == "memory-integral" ||
 		metric == "branch-mispred" ||

--- a/tools/compare/UnixRunner.cs
+++ b/tools/compare/UnixRunner.cs
@@ -79,16 +79,13 @@ namespace compare
 		}
 
 		private int GetTimeout() {
-			int timeout;
-			if (machine != null) {
-				if (machine.BenchmarkTimeouts != null && machine.BenchmarkTimeouts.ContainsKey(benchmark.Name))
-					timeout = machine.BenchmarkTimeouts[benchmark.Name];
-				else
-					timeout = machine.DefaultTimeout;
-			} else {
-				timeout = defaultTimeoutSeconds;
-			}
-			return timeout;
+			if (machine == null)
+				return defaultTimeoutSeconds;
+
+			if (machine.BenchmarkTimeouts == null || !machine.BenchmarkTimeouts.ContainsKey (benchmark.Name))
+				return machine.DefaultTimeout;
+
+			return machine.BenchmarkTimeouts[benchmark.Name];
 		}
 
 		private static void PrintCommandLine(String prefix, ProcessStartInfo info) {

--- a/tools/compare/UnixRunner.cs
+++ b/tools/compare/UnixRunner.cs
@@ -72,8 +72,10 @@ namespace compare
 				arguments = "--stats " + arguments;
 		}
 
-		public Boolean IsAOT() {
-			return InfoAot != null;
+		public bool IsAot {
+			get {
+				return InfoAot != null;
+			}
 		}
 
 		private int GetTimeout() {

--- a/tools/compare/compare.cs
+++ b/tools/compare/compare.cs
@@ -634,7 +634,7 @@ class Compare
 
 				var runner = new compare.UnixRunner (testsDir, config, benchmark, machine, timeout, runTool, runToolArguments);
 
-				if (runner.IsAOT()) {
+				if (runner.IsAot) {
 					bool timedOut;
 					string stdoutOutput;
 					var elapsedMilliseconds = runner.RunAOT(out timedOut, out stdoutOutput);

--- a/tools/libdbmodel/Benchmark.cs
+++ b/tools/libdbmodel/Benchmark.cs
@@ -14,6 +14,7 @@ namespace Benchmarker.Models
 		public bool OnlyExplicit {get; set; }
 		public string[] CommandLine { get; set; }
 		public string[] ClientCommandLine { get; set; }
+		public string[] AOTAssemblies { get; set; }
 
 		public Benchmark ()
 		{

--- a/tools/libdbmodel/Config.cs
+++ b/tools/libdbmodel/Config.cs
@@ -24,6 +24,8 @@ namespace Benchmarker.Models
 
 		public string Mono { get; set; }
 
+		public string[] AOTOptions { get; set; }
+
 		public string[] MonoOptions { get; set; }
 
 		public Dictionary<string, string> MonoEnvironmentVariables { get; set; }

--- a/tools/libdbmodel/Result.cs
+++ b/tools/libdbmodel/Result.cs
@@ -20,7 +20,8 @@ namespace Benchmarker.Models
 			PauseTimes,
 			PauseStarts,
 			CodeSize,
-			JitPhase
+			JitPhase,
+			AOTTime
 		};
 
 		public MetricType Metric { get; set; }
@@ -34,6 +35,8 @@ namespace Benchmarker.Models
 				switch (Metric) {
 				case MetricType.Time:
 					return "time";
+				case MetricType.AOTTime:
+					return "aot-time";
 				case MetricType.MemoryIntegral:
 					return "memory-integral";
 				case MetricType.Instructions:
@@ -62,6 +65,7 @@ namespace Benchmarker.Models
 			get {
 				switch (Metric) {
 				case MetricType.Time:
+				case MetricType.AOTTime:
 				case MetricType.JitPhase:
 					return ((TimeSpan)Value).TotalMilliseconds;
 				case MetricType.MemoryIntegral:


### PR DESCRIPTION
In order to execute the AOT step, two conditions must be met:
* the configuration must contain a `AOTOptions` field
* each benchmark that is known to work with AOT, must list all its assemblies in `AOTAssemblies`

So far, I only added `roslyn` (yeah, this benchmark works with AOT! 👍 ). I'll add more benchmarks tomorrow. Also, the `http-api` change is already deployed.

@schani: What are your thoughts on this?